### PR TITLE
ci: remove duplicate canary job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
     - stage: 'Canary Tests'
       script:


### PR DESCRIPTION
I noticed while working on #17 that there are two canary
jobs running, so this removes the non-allowed_failures one.