### PR TITLE
Remove deprecation warnings

### DIFF
--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,12 +1,12 @@
 import Application from '../../app';
 import config from '../../config/environment';
-import { merge } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
-  let attributes = merge({}, config.APP);
+  let attributes = assign({}, config.APP);
   attributes.autoboot = true;
-  attributes = merge(attributes, attrs); // use defaults, but you can override;
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {
     let application = Application.create(attributes);

--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -95,7 +95,7 @@
   Ember.Route.reopen(routeProps);
 
   Ember.Router.reopen({
-    updateTitle: Ember.on('didTransition', function() {
+    updateTitle: Ember.on('routeDidChange', function() {
       this.send('collectTitleTokens', []);
     }),
 


### PR DESCRIPTION
This PR attempts to remove two deprecation warnings caused by:
1. https://deprecations.emberjs.com/v3.x/#toc_ember-polyfills-deprecate-merge
2. https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events

